### PR TITLE
Update roll.js - use round and remove int check

### DIFF
--- a/commands/math/roll.js
+++ b/commands/math/roll.js
@@ -15,11 +15,11 @@ class RollCommand extends commando.Command {
     async run(message, args) {
         var args_aux = args.split(" ");
 
-        var min = Math.ceil(args_aux[0]);
-        var max = Math.floor(args_aux[1]);
-        var roll = Math.floor(Math.random() * (max - min)) + min;
+        var min = Math.round(args_aux[0]);
+        var max = Math.round(args_aux[1]);
+        var roll = Math.round(Math.random() * (max - min)) + min;
 
-        if(args_aux.length == 2 && Number.isInteger(roll)){
+        if(args_aux.length == 2){
             message.reply("You rolled a " + roll);
         } else {
             message.reply("Something went wrong... Use '!help' command to know more about this.");

--- a/commands/math/roll.js
+++ b/commands/math/roll.js
@@ -17,12 +17,17 @@ class RollCommand extends commando.Command {
 
         var min = Math.round(args_aux[0]);
         var max = Math.round(args_aux[1]);
-        var roll = Math.round(Math.random() * (max - min)) + min;
+        if (isNaN(min) || isNaN(max)) {
+            message.reply("the limits must be numbers")
+        }
+        else {
+            var roll = Math.round(Math.random() * (max - min)) + min;
 
-        if(args_aux.length == 2){
-            message.reply("You rolled a " + roll);
-        } else {
-            message.reply("Something went wrong... Use '!help' command to know more about this.");
+            if(args_aux.length == 2){
+                message.reply("You rolled a " + roll);
+            } else {
+                message.reply("Something went wrong... Use '!help' command to know more about this.");
+            }
         }
     }
 }


### PR DESCRIPTION
Math.round() already returns an int so checking if roll is an int is unnecessary, roll will always be an int.
Using Math.round() instead of Math.ceil() and Math.floor() because an input like 0.05 shouldn't round up to 1 and one like 0.95 shouldn't round down to 0.